### PR TITLE
Remove unsupported plugin

### DIFF
--- a/main.scss
+++ b/main.scss
@@ -167,7 +167,6 @@ $version: '6.3.0';
 @import 'src/bd/plugins/DevilBro/dateText';
 @import 'src/bd/plugins/DevilBro/gameActivityToggle';
 @import 'src/bd/plugins/DevilBro/ownerTag';
-@import 'src/bd/plugins/DevilBro/showHiddenChannels';
 @import 'src/bd/plugins/DevilBro/tooltips';
 @import 'src/bd/plugins/Finicalmist/copyCode';
 @import 'src/bd/plugins/noodlebox/lineNumbers';

--- a/src/bd/plugins/DevilBro/showHiddenChannels.scss
+++ b/src/bd/plugins/DevilBro/showHiddenChannels.scss
@@ -1,4 +1,0 @@
-// SHOW HIDDEN CHANNELS
-.container-hidden {
-  opacity: 0.3;
-}


### PR DESCRIPTION
DevilBro is no longer supporting this plugin and has recommended uninstalling it. 