### PR TITLE
Reduce padding on inline codeblocks to prevent overlapping

### DIFF
--- a/src/messages/codeblock.scss
+++ b/src/messages/codeblock.scss
@@ -2,7 +2,7 @@
 %markup {
   // INLINE CODE
   code%codeInline {
-    padding: 3.5px 7.5px;
+    padding: 1px 5px;
     background-color: hsla(0, 0%, 100%, 0.1);
     border-radius: 3px;
     color: hsla(0, 0%, 100%, 0.7);


### PR DESCRIPTION
Before
![image](https://github.com/user-attachments/assets/d4be7218-82f2-4d53-8e45-0aaf858b8391)
After
![image](https://github.com/user-attachments/assets/8369c2b7-886a-44d3-bf07-6e832ebc2115)
