### PR TITLE
Fix new message bar taking up entire chat

### DIFF
--- a/src/chat/bars.scss
+++ b/src/chat/bars.scss
@@ -4,6 +4,8 @@
   z-index: 999;
   background: transparent;
   transition: all 0.15s ease-in-out;
+  display: flex;
+  align-items: center;
   &:before {
     content: '';
     position: absolute;
@@ -13,6 +15,7 @@
     opacity: 0.8;
     z-index: -1;
     transition: all 0.15s ease-in-out;
+    height: 32px;
   }
   &:hover,
   &:active {


### PR DESCRIPTION
## Before
![Before](https://github.com/user-attachments/assets/129a96fb-6aff-4b05-bde4-33cbc7fcd407)

## After
![After](https://github.com/user-attachments/assets/6bffd969-8337-49f1-ace7-7d80805e4237)

## My comment
Before and after the code change, I sadly cant remember if the mark as read button was floated to the right but if it is, ig make that change after merging this.