### PR TITLE
Update accountPanel selector

### DIFF
--- a/lib/selectors/selectorPlaceholders.scss
+++ b/lib/selectors/selectorPlaceholders.scss
@@ -468,7 +468,7 @@
 .lottieIcon__5eb9b {
   @extend %panelActionButtonLottieIcon !optional;
 }
-.container__37e49 {
+.content__37e49 {
   @extend %accountPanel !optional;
 }
 .avatarWrapper__37e49 {


### PR DESCRIPTION
Unless this is some wack ass experiment discord are pushing the accountPanel is no longer themed, this fixes that

## Before
![image](https://github.com/user-attachments/assets/e843fa20-6a38-4738-abb7-96d7eca08a9a)

## After
![image](https://github.com/user-attachments/assets/45a24514-5d34-4576-aed6-346ecc30fd44)
