### PR TITLE
Improvement: Message hover background customization

### DIFF
--- a/src/defaultSettings.scss
+++ b/src/defaultSettings.scss
@@ -6,6 +6,7 @@
   --danger-color: #982929;
   --channel-color: rgba(255, 255, 255, 0.3);
   --channel-hovered: rgba(255, 255, 255, 0.7);
+  --message-hovered: rgba(255, 255, 255, 0.05);
   --channel-unread: var(--main-color);
   --channel-selected: #fff;
   --channel-muted: rgba(255, 255, 255, 0.1);

--- a/src/defaultSettings.scss
+++ b/src/defaultSettings.scss
@@ -6,11 +6,11 @@
   --danger-color: #982929;
   --channel-color: rgba(255, 255, 255, 0.3);
   --channel-hovered: rgba(255, 255, 255, 0.7);
-  --message-hovered: rgba(255, 255, 255, 0.05);
   --channel-unread: var(--main-color);
   --channel-selected: #fff;
   --channel-muted: rgba(255, 255, 255, 0.1);
   --server-unread: var(--main-color);
+  --background-message-hover: rgba(255, 255, 255, 0.05);
   --url-color: var(--main-color);
   --focus-color: var(--main-color);
   --online-color: #43b581;

--- a/src/messages/message.scss
+++ b/src/messages/message.scss
@@ -14,6 +14,9 @@
       color: hsla(0, 0%, 100%, 0.5);
     }
   }
+  &:hover {
+    background-color: var(--message-hovered) !important;
+  }
 }
 // SYSTEM MESSAGE
 %messageSystemContainer {

--- a/src/messages/message.scss
+++ b/src/messages/message.scss
@@ -14,9 +14,6 @@
       color: hsla(0, 0%, 100%, 0.5);
     }
   }
-  &:hover {
-    background-color: var(--message-hovered) !important;
-  }
 }
 // SYSTEM MESSAGE
 %messageSystemContainer {


### PR DESCRIPTION
# Changes made
Added a new variable called `--message-hovered` with a default value of `rgba(255, 255, 255, 0.05)` which allows the user to change the message hover background color.

Unsure if my implementation is desirable, as you could also just modify Discord's built in `--background-message-hover`

## Before (GIF)
![GIF showcasing lack of message hover color changes](https://github.com/user-attachments/assets/0244729d-d024-4ab0-b609-78cc3ec2836e)
The hover effect darkens the message background very slightly almost to the point of being indistinguishable from a non hovered message

## After (GIF)
![GIF showcasing message hover color changes](https://github.com/user-attachments/assets/ce304274-5727-4272-b261-6edb7ba907cf)
After the changes, the message hover affect works well with the default theme preset when using white at .05% opacity for hover effect.