### PR TITLE
Clarity in V6 Notice

### DIFF
--- a/src/fixespt2.scss
+++ b/src/fixespt2.scss
@@ -18,7 +18,7 @@
 
 // notice
 .visual-refresh::before {
-  content: "v6 is discontinued, please download v7 from the clearvision discord, github or bd website";
+  content: "clearvision v6 is discontinued, please download v7 from the clearvision github, discord or bd website";
   text-align: center;
   position: absolute;
   color: #fff;


### PR DESCRIPTION
Too many people in the Vencord Discord don't seem to understand that "v6" is referring to ClearVision V6, and not "vencord v6". I understand it is a small change, but I think it's probably better to be more clear about this.